### PR TITLE
added PyQt5 import statement to solve GUI issue on WSL

### DIFF
--- a/src/nexus/nexus.py
+++ b/src/nexus/nexus.py
@@ -5,6 +5,7 @@ import subprocess
 from multiprocessing import Process, Queue, Manager, cpu_count
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 import numpy as np
+from PyQt5 import QtGui, QtWidgets
 import pyarrow.plasma as plasma
 from importlib import import_module
 from nexus import store


### PR DESCRIPTION
Two issues to resolve when testing this on my system:
1) Move basic_demo.yaml from rasp to src directory
2) Edit path in _startStore() method in nexus.py so that plasma store starts properly
Ex. `self.p_Limbo = subprocess.Popen(['/home/ray/.local/lib/python3.6/site-packages/pyarrow/plasma_store_server', '-s', '/tmp/store', '-m', 'str(100000000)],)`